### PR TITLE
Adopt PSR-4 to autoload the whole package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,8 @@
         "zendframework/zend-stdlib": "2.*"
     },
     "autoload": {
-        "files": ["src/ApiClient.php"],
-        "psr-0": {
-            "": "src/"
+        "psr-4": {
+            "Zanox\\": "src/"
         }
     }
 }


### PR DESCRIPTION
Thanks to PSR-4 the entire package can be auto-loaded when used in third party application.